### PR TITLE
TokenSerializer에 토큰을 검사하여 만료되었을 경우 해당 토큰을 삭제 유효할 경우 해당 토큰의 유효기간을 현재시간…

### DIFF
--- a/django_app/user/views/api.py
+++ b/django_app/user/views/api.py
@@ -108,7 +108,12 @@ class LoginAPIView(GenericAPIView):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         user_object = serializer.save()
-        token, _ = TemporaryToken.objects.get_or_create(user=user_object)
+        token, exists = TemporaryToken.objects.get_or_create(user=user_object)
+        if exists:
+            pass
+        elif token.expired:
+            token.delete()
+            token = TemporaryToken.objects.create(user=user_object)
         user = NormalUserCreateSerializer(user_object)
         return Response(status=status.HTTP_200_OK, data={'user': user.data,
                                                          'key': token.key})


### PR DESCRIPTION
…부터 한달로 연장하도록 수정, ChangePersonalSerializer의 nickname필드의 UniqueValidator설정, user/views/api.py의 로그인시 기존 토큰이 없을 경우에는 생성해 주고 기존 토큰이 있는데 만료되었을 경우 기존 토큰을 삭제하고 새로운 토큰을 발행하도록 수정'